### PR TITLE
API key will not be saved if value is 'hidden'

### DIFF
--- a/templates/kos.html
+++ b/templates/kos.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 	<style> /* all styling by BrookeAFK she is the best person ever!!! */
 		.kos {
@@ -6,7 +7,7 @@
 			background-color: #323232;
 			text-align: left;
 			width: 70%;
-			margin: 10px auto;
+			margin: 10px;
 			height: 80px;
 		}
 
@@ -106,6 +107,7 @@
 
 		button {
 			all: inherit;
+			cursor: pointer;
 			outline: 0px;
 			border-radius: 10px;
 			padding: 10px 40px 10px 40px;
@@ -313,7 +315,7 @@
 			function saveApiKey(){
 				let apiKeyTextBoxValue = document.getElementById("apikeytextbox").value;
 
-				if (true){ // check if value matches the format of keys (length etc.)
+				if (!(apiKeyTextBoxValue == 'hidden')){ // check if value matches the format of keys (length etc.)
 					apiKey = apiKeyTextBoxValue;
 					document.cookie = `apiKey=${apiKey}`;
 


### PR DESCRIPTION
When clicking the "Save API key" button when the value is hidden, the API key will be saved as `hidden`, deleting the saved key inside it. This PR resolves that issue.